### PR TITLE
Make transaction isolation level a configurable setting

### DIFF
--- a/Examples/CrossBreeze_CrossTest_ExampleTests/App.config
+++ b/Examples/CrossBreeze_CrossTest_ExampleTests/App.config
@@ -1,10 +1,10 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
 
 	<configSections>
-		<section name="crossTest" type="CrossBreeze.CrossTest.SpecFlow.Configuration.CrossTestConfig, CrossBreeze.CrossTest.SpecFlow.Core" />
-		<section name="crossTestSsis" type="CrossBreeze.CrossTest.Process.Ssis.Configuration.crossTestSsisConfig, CrossBreeze.CrossTest.Process.Ssis" />
-		<section name="crossTestAdf" type="CrossBreeze.CrossTest.Process.Adf.Configuration.crossTestAdfConfig, CrossBreeze.CrossTest.Process.Adf" />
+		<section name="crossTest" type="CrossBreeze.CrossTest.SpecFlow.Configuration.CrossTestConfig, CrossBreeze.CrossTest.SpecFlow.Core"/>
+		<section name="crossTestSsis" type="CrossBreeze.CrossTest.Process.Ssis.Configuration.crossTestSsisConfig, CrossBreeze.CrossTest.Process.Ssis"/>
+		<section name="crossTestAdf" type="CrossBreeze.CrossTest.Process.Adf.Configuration.crossTestAdfConfig, CrossBreeze.CrossTest.Process.Adf"/>
 	</configSections>
 
 	<!-- The CrossTest configuration -->
@@ -13,91 +13,91 @@
 		<!-- Test configuration. -->
 		<test>
 			<namingConvention>
-				<tableHeader parameterName="Parameter" parameterValue="Value" />
+				<tableHeader parameterName="Parameter" parameterValue="Value"/>
 			</namingConvention>
 
 			<objectTemplates>
 				<!-- The common types which can be used as a parent for table, function and procedure types. -->
-				<objectTemplate name="sys" prefix="[sys].[" suffix="]" />
+				<objectTemplate name="sys" prefix="[sys].[" suffix="]"/>
 				<objectTemplate name="sys2" prefix="[sys].[" suffix="]">
 					<attributes>
-						<attribute name="file_or_directory" value="C:\\Not_a_real_file" />
+						<attribute name="file_or_directory" value="C:\\Not_a_real_file"/>
 					</attributes>
 				</objectTemplate>
-				<objectTemplate name="dbo" prefix="[dbo].[" suffix="]" />
+				<objectTemplate name="dbo" prefix="[dbo].[" suffix="]"/>
 				<objectTemplate name="dbo2" prefix="[dbo].[" suffix="]">
 					<attributes>
-						<attribute name="ExampleColumn" value="Some data2" />
+						<attribute name="ExampleColumn" value="Some data2"/>
 					</attributes>
 				</objectTemplate>
 
 				<!-- The table types which can be used while filling tables. The attributes defined here will be used as columns for the table. -->
-				<objectTemplate name="staging" prefix="[Staging].[" suffix="]" />
+				<objectTemplate name="staging" prefix="[Staging].[" suffix="]"/>
 				<objectTemplate name="staging-storage" parentTemplate="staging">
 					<attributes>
-						<attribute name="StageDateTime" value="2000-01-01 00:00:00.00" />
+						<attribute name="StageDateTime" value="2000-01-01 00:00:00.00"/>
 					</attributes>
 				</objectTemplate>
 				<objectTemplate name="staging-hist-storage" parentTemplate="staging-storage" appendPrefix="HIST_">
 					<attributes>
-						<attribute name="RecordHash" value="0x00000000000000000000000000000000" />
-						<attribute name="RecordEndDateTime" value="9999-12-31 00:00:00.00" />
+						<attribute name="RecordHash" value="0x00000000000000000000000000000000"/>
+						<attribute name="RecordEndDateTime" value="9999-12-31 00:00:00.00"/>
 					</attributes>
 				</objectTemplate>
 				<!-- The following objectTemplate can, for example, be applied on a T-SQL procedure or a SSIS process. -->
 				<objectTemplate name="load-staging" parentTemplate="staging" appendPrefix="Load_">
 					<attributes>
-						<attribute name="ParentProcessID" value="1" />
-						<attribute name="ProcessDateTime" value="2000-01-01 00:00:00.00" />
+						<attribute name="ParentProcessID" value="1"/>
+						<attribute name="ProcessDateTime" value="2000-01-01 00:00:00.00"/>
 					</attributes>
 				</objectTemplate>
 				
 				<!-- DataVault storage object types. -->
-				<objectTemplate name="datavault" prefix="[DataVault].[" suffix="]" />
+				<objectTemplate name="datavault" prefix="[DataVault].[" suffix="]"/>
 				<objectTemplate name="datavault-storage" parentTemplate="datavault">
 					<attributes>
-						<attribute name="RecordLoadProcessID" value="1" />
-						<attribute name="RecordLoadDateTime" value="2000-01-01 00:00:00.00" />
+						<attribute name="RecordLoadProcessID" value="1"/>
+						<attribute name="RecordLoadDateTime" value="2000-01-01 00:00:00.00"/>
 					</attributes>
 				</objectTemplate>
-				<objectTemplate name="sourcelink" parentTemplate="datavault-storage" appendPrefix="SL_" />
-				<objectTemplate name="hub" parentTemplate="datavault-storage" appendPrefix="H_" />
-				<objectTemplate name="link" parentTemplate="datavault-storage" appendPrefix="L_" />
+				<objectTemplate name="sourcelink" parentTemplate="datavault-storage" appendPrefix="SL_"/>
+				<objectTemplate name="hub" parentTemplate="datavault-storage" appendPrefix="H_"/>
+				<objectTemplate name="link" parentTemplate="datavault-storage" appendPrefix="L_"/>
 				<objectTemplate name="satellite" parentTemplate="datavault-storage" appendPrefix="S_">
 					<attributes>
-						<attribute name="RecordHash" value="0x00000000000000000000000000000000" />
-						<attribute name="RecordEndDateTime" value="9999-12-31 00:00:00.00" />
+						<attribute name="RecordHash" value="0x00000000000000000000000000000000"/>
+						<attribute name="RecordEndDateTime" value="9999-12-31 00:00:00.00"/>
 					</attributes>
 				</objectTemplate>
 				<!-- The following objectTemplate can, for example, be applied on a T-SQL procedure or a SSIS process. -->
 				<objectTemplate name="dwh" parentTemplate="datavault" appendPrefix="Load_">
 					<attributes>
-						<attribute name="ParentProcessID" value="1" />
-						<attribute name="ProcessDateTime" value="2000-01-01 00:00:00.00" />
+						<attribute name="ParentProcessID" value="1"/>
+						<attribute name="ProcessDateTime" value="2000-01-01 00:00:00.00"/>
 					</attributes>
 				</objectTemplate>
 
 				<!-- The following objectTemplate can, for example, be applied on a T-SQL procedure or a SSIS process. -->
 				<objectTemplate name="adfTemplate" parentTemplate="datavault" appendPrefix="Load_">
 					<attributes>
-						<attribute name="baseUrl" value="https://test.crossbreeze.nl/" />
+						<attribute name="baseUrl" value="https://test.crossbreeze.nl/"/>
 					</attributes>
 				</objectTemplate>
 
 				<!-- DataMart storage object types. -->
 				<objectTemplate name="datamart" prefix="[DataMart].[" suffix="]">
 					<attributes>
-						<attribute name="RecordHash" value="0x00000000000000000000000000000000" />
-						<attribute name="RecordEndDateTime" value="9999-12-31 00:00:00.00" />
+						<attribute name="RecordHash" value="0x00000000000000000000000000000000"/>
+						<attribute name="RecordEndDateTime" value="9999-12-31 00:00:00.00"/>
 					</attributes>
 				</objectTemplate>
-				<objectTemplate name="dimension" parentTemplate="datamart" />
-				<objectTemplate name="fact" parentTemplate="datamart" />
+				<objectTemplate name="dimension" parentTemplate="datamart"/>
+				<objectTemplate name="fact" parentTemplate="datamart"/>
 
 				<!-- The function types which can be used while calling functions. -->
-				<objectTemplate name="business-rule" prefix="[BusinessRule].[udf_" suffix="]" />
-				<objectTemplate name="derive" parentTemplate="business-rule" appendPrefix="Derive_" />
-				<objectTemplate name="calculate" parentTemplate="business-rule" appendPrefix="Calculate_" />
+				<objectTemplate name="business-rule" prefix="[BusinessRule].[udf_" suffix="]"/>
+				<objectTemplate name="derive" parentTemplate="business-rule" appendPrefix="Derive_"/>
+				<objectTemplate name="calculate" parentTemplate="business-rule" appendPrefix="Calculate_"/>
 			</objectTemplates>
 		</test>
 
@@ -106,8 +106,8 @@
 
 			<!-- The database servers which are used, the connectionStringName points to the name of the connectionStrings element defined in this app config. -->
 			<servers>
-				<server name="ExampleMsSqlServer" connectionName="ExampleMsSqlConnection" type="MsSql" commandTimeout="10" />
-				<server name="ExampleMsSsasServer" connectionName="ExampleMsSsasConnection" type="MsSsas" />
+				<server name="ExampleMsSqlServer" connectionName="ExampleMsSqlConnection" type="MsSql" commandTimeout="10" transactionIsolationLevel="Snapshot"/>
+				<server name="ExampleMsSsasServer" connectionName="ExampleMsSsasConnection" type="MsSsas"/>
 			</servers>
 
 		</database>
@@ -124,13 +124,13 @@
 		<SsisProcesses>
 			<!-- The SSIS process types are: IsPacProjectProcess, DBProjectProcess, FileProcess -->
 			<!-- Example SSIS ISPac project. -->
-			<SsisProcess name="ExampleSsisISPacProject" processType="ISPac" isPacFileLocation=".\Examples\CrossBreeze_CrossTest_ExampleTests\ProcessSteps\SupportFiles\ExampleSSISProject\bin\Development\ExampleSSISProject.ispac" />
+			<SsisProcess name="ExampleSsisISPacProject" processType="ISPac" isPacFileLocation=".\Examples\CrossBreeze_CrossTest_ExampleTests\ProcessSteps\SupportFiles\ExampleSSISProject\bin\Development\ExampleSSISProject.ispac"/>
 		</SsisProcesses>
 	</crossTestSsis>
 
 	<crossTestAdf>
 		<AdfProcesses>
-			<AdfProcess name="ExampleAdfPipeline" processType="AdfPipeline" tenantID="8ccf7167-19f0-4c07-918e-160fbb607c93" subscriptionId="b91a490b-693f-4d52-bcf9-ea0d26553db2" applicationId="3d82885e-d652-488c-9c34-646c6b3ad979" clientSecret="ojG8Q~AVBdKRnTRBVVMNqjXVJxU7ZmCzjAqWodxF" resourceGroupName="CrossBreeze_CrossTest" dataFactoryName="XB-ADF-CrossTest" />
+			<AdfProcess name="ExampleAdfPipeline" processType="AdfPipeline" tenantID="8ccf7167-19f0-4c07-918e-160fbb607c93" subscriptionId="b91a490b-693f-4d52-bcf9-ea0d26553db2" applicationId="3d82885e-d652-488c-9c34-646c6b3ad979" clientSecret="ojG8Q~AVBdKRnTRBVVMNqjXVJxU7ZmCzjAqWodxF" resourceGroupName="CrossBreeze_CrossTest" dataFactoryName="XB-ADF-CrossTest"/>
 		</AdfProcesses>
 	</crossTestAdf>
 
@@ -144,7 +144,7 @@
 	<!-- The connection strings. -->
 	<connectionStrings>
 		<!-- Define the database servers to use. The name is the name of the server and the connection string should be without a database. -->
-		<add name="ExampleMsSqlConnection" connectionString="Data Source=localhost;User Id=sa;Password=Test1234;" />
-		<add name="ExampleMsSsasConnection" connectionString="Data Source=localhost\LocalDev2017;" />
+		<add name="ExampleMsSqlConnection" connectionString="Data Source=localhost\LocalDev2017;Integrated Security=SSPI;"/>
+		<add name="ExampleMsSsasConnection" connectionString="Data Source=localhost\LocalDev2017;"/>
 	</connectionStrings>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7"/></startup></configuration>

--- a/Examples/CrossBreeze_CrossTest_ExampleTests/App.config
+++ b/Examples/CrossBreeze_CrossTest_ExampleTests/App.config
@@ -106,7 +106,7 @@
 
 			<!-- The database servers which are used, the connectionStringName points to the name of the connectionStrings element defined in this app config. -->
 			<servers>
-				<server name="ExampleMsSqlServer" connectionName="ExampleMsSqlConnection" type="MsSql" commandTimeout="10" transactionIsolationLevel="Snapshot"/>
+				<server name="ExampleMsSqlServer" connectionName="ExampleMsSqlConnection" type="MsSql" commandTimeout="10" isolationLevel="Snapshot"/>
 				<server name="ExampleMsSsasServer" connectionName="ExampleMsSsasConnection" type="MsSsas"/>
 			</servers>
 
@@ -144,7 +144,7 @@
 	<!-- The connection strings. -->
 	<connectionStrings>
 		<!-- Define the database servers to use. The name is the name of the server and the connection string should be without a database. -->
-		<add name="ExampleMsSqlConnection" connectionString="Data Source=localhost\LocalDev2017;Integrated Security=SSPI;"/>
+    <add name="ExampleMsSqlConnection" connectionString="Data Source=localhost;User Id=sa;Password=Test1234;" />
 		<add name="ExampleMsSsasConnection" connectionString="Data Source=localhost\LocalDev2017;"/>
 	</connectionStrings>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7"/></startup></configuration>

--- a/Examples/CrossBreeze_CrossTest_ExampleTests/CrossBreeze.CrossTest.ExampleTests.csproj
+++ b/Examples/CrossBreeze_CrossTest_ExampleTests/CrossBreeze.CrossTest.ExampleTests.csproj
@@ -50,6 +50,7 @@
     <None Include="DatabaseSteps\ExampleDatabaseQuerySteps_NL.feature" />
     <None Include="DatabaseSteps\ExampleDatabaseFunctionSteps_EN.feature" />
     <None Include="DatabaseSteps\ExampleDatabaseSqlAgentJobSteps_EN.feature" />
+    <None Include="DatabaseSteps\ExampleDatabaseTableStepsInTransaction_EN.feature" />
     <None Include="DatabaseSteps\ExampleDatabaseTableSteps_DataTypes.feature" />
     <None Include="DatabaseSteps\ExampleDatabaseTableSteps_EN.feature" />
     <None Include="DatabaseSteps\ExampleDatabaseTableSteps_NL.feature" />

--- a/Examples/CrossBreeze_CrossTest_ExampleTests/DatabaseSteps/ExampleDatabaseTableStepsInTransaction_EN.feature
+++ b/Examples/CrossBreeze_CrossTest_ExampleTests/DatabaseSteps/ExampleDatabaseTableStepsInTransaction_EN.feature
@@ -1,0 +1,42 @@
+#language: en
+Feature: Database table test steps in a transaction
+
+Background:
+	Given the ExampleMsSqlServer database server is used
+	And the ExampleDatabase database is used
+	When I execute the following SQL query:
+		"""
+		IF OBJECT_ID('dbo.xt_transaction_test') IS NULL
+		BEGIN
+		CREATE TABLE dbo.[xt_transaction_test] (
+			[Id] int,
+			[Description] varchar(50)
+		)
+		END
+		"""
+
+Scenario: Simple insert 
+	When the test is being executed within a transaction
+	Given the table [xt_transaction_test] is loaded with the following data:
+	| Id | Description  |
+	| 1  | Test         |
+	| 2  | Another test |
+
+	When I retrieve the contents of the [dbo].[xt_transaction_test] table
+	Then I expect the following results:
+	| Id | Description  |
+	| 1  | Test         |
+	| 2  | Another test |
+
+Scenario: Another Simple insert 
+	When the test is being executed within a transaction
+	Given the table [xt_transaction_test] is loaded with the following data:
+	| Id | Description  |
+	| 1  | Test         |
+	| 2  | Another test |
+
+	When I retrieve the contents of the [dbo].[xt_transaction_test] table
+	Then I expect the following results:
+	| Id | Description  |
+	| 1  | Test         |
+	| 2  | Another test |

--- a/Examples/CrossBreeze_CrossTest_ExampleTests/DatabaseSteps/ExampleDatabaseTableStepsInTransaction_EN.feature
+++ b/Examples/CrossBreeze_CrossTest_ExampleTests/DatabaseSteps/ExampleDatabaseTableStepsInTransaction_EN.feature
@@ -32,11 +32,11 @@ Scenario: Another Simple insert
 	When the test is being executed within a transaction
 	Given the table [xt_transaction_test] is loaded with the following data:
 	| Id | Description  |
-	| 1  | Test         |
-	| 2  | Another test |
+	| 3  | Test         |
+	| 4  | Another test |
 
 	When I retrieve the contents of the [dbo].[xt_transaction_test] table
 	Then I expect the following results:
 	| Id | Description  |
-	| 1  | Test         |
-	| 2  | Another test |
+	| 3  | Test         |
+	| 4  | Another test |

--- a/Examples/CrossBreeze_CrossTest_ExampleTests/prepare_sql_docker.sql
+++ b/Examples/CrossBreeze_CrossTest_ExampleTests/prepare_sql_docker.sql
@@ -4,6 +4,10 @@ GO
 USE [ExampleDatabase]
 GO
 
+ALTER DATABASE ExampleDatabase
+SET ALLOW_SNAPSHOT_ISOLATION ON
+GO
+
 -- Create all database objects for testing in the current database.
 :r prepare_sql_database.sql
 

--- a/Examples/CrossBreeze_CrossTest_ExampleTests/sqlserver_server.ps1
+++ b/Examples/CrossBreeze_CrossTest_ExampleTests/sqlserver_server.ps1
@@ -9,4 +9,4 @@ docker run -e 'ACCEPT_EULA=Y' -e 'SA_PASSWORD=Test1234' -e 'MSSQL_AGENT_ENABLED=
 Start-Sleep -s 10
 
 # Execute sql script needed to run tests on the server
-docker exec -w /scripts crosstest_specflow_sqlserver /opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P Test1234 -i prepare_sql_docker.sql
+docker exec -w /scripts crosstest_specflow_sqlserver /opt/mssql-tools18/bin/sqlcmd -S localhost -U SA -P Test1234 -C -i prepare_sql_docker.sql

--- a/Lib/CrossBreeze_CrossTest_Database/Configuration/DatabaseServerConfig.cs
+++ b/Lib/CrossBreeze_CrossTest_Database/Configuration/DatabaseServerConfig.cs
@@ -55,6 +55,11 @@ namespace CrossBreeze.CrossTest.Database.Configuration
         [XDoc(Description ="The name of the connection string defined in the config, that this database server config refers to.")]
         public string ConnectionName => this["connectionName"] as string;
 
+        // Transaction isolation level
+        [ConfigurationProperty("transactionIsolationLevel", DefaultValue = "Serializable")]
+        [XDoc(Description = "The type of isolation level that is applied when running tests in a transaction.")]
+        public string TransactionIsolationLevel => this["transactionIsolationLevel"] as string;
+
 
     }
 }

--- a/Lib/CrossBreeze_CrossTest_Database/Configuration/DatabaseServerConfig.cs
+++ b/Lib/CrossBreeze_CrossTest_Database/Configuration/DatabaseServerConfig.cs
@@ -56,9 +56,9 @@ namespace CrossBreeze.CrossTest.Database.Configuration
         public string ConnectionName => this["connectionName"] as string;
 
         // Transaction isolation level
-        [ConfigurationProperty("transactionIsolationLevel", DefaultValue = "Serializable")]
+        [ConfigurationProperty("isolationLevel", DefaultValue = "Serializable")]
         [XDoc(Description = "The type of isolation level that is applied when running tests in a transaction.")]
-        public string TransactionIsolationLevel => this["transactionIsolationLevel"] as string;
+        public string IsolationLevel => this["isolationLevel"] as string;
 
 
     }

--- a/Lib/CrossBreeze_CrossTest_SpecFlow_Core/Modules/Data/Database/DatabaseContext.cs
+++ b/Lib/CrossBreeze_CrossTest_SpecFlow_Core/Modules/Data/Database/DatabaseContext.cs
@@ -38,7 +38,7 @@ namespace CrossBreeze.CrossTest.SpecFlow.Modules.Data.Database.Context
         public void BeginTransaction(ScenarioContext scenarioContext)
         {
             // Begin the transaction with configured isolation level.
-            DatabaseTransaction = DatabaseConnection.BeginTransaction((IsolationLevel)System.Enum.Parse(typeof(IsolationLevel), this.databaseServerConfig.TransactionIsolationLevel));
+            DatabaseTransaction = DatabaseConnection.BeginTransaction((IsolationLevel)System.Enum.Parse(typeof(IsolationLevel), this.databaseServerConfig.IsolationLevel));
         }
 
         public bool IsTransactionOpen()

--- a/Lib/CrossBreeze_CrossTest_SpecFlow_Core/Modules/Data/Database/DatabaseContext.cs
+++ b/Lib/CrossBreeze_CrossTest_SpecFlow_Core/Modules/Data/Database/DatabaseContext.cs
@@ -37,8 +37,8 @@ namespace CrossBreeze.CrossTest.SpecFlow.Modules.Data.Database.Context
 
         public void BeginTransaction(ScenarioContext scenarioContext)
         {
-            // Begin the transaction with Serializable isolation level.
-            DatabaseTransaction = DatabaseConnection.BeginTransaction(IsolationLevel.Serializable);
+            // Begin the transaction with configured isolation level.
+            DatabaseTransaction = DatabaseConnection.BeginTransaction((IsolationLevel)System.Enum.Parse(typeof(IsolationLevel), this.databaseServerConfig.TransactionIsolationLevel));
         }
 
         public bool IsTransactionOpen()


### PR DESCRIPTION
Running tests in parallel gives deadlock issues when trying to read and write from the same table at the same time.
Using the snapshot isolation level that SQL Server implements these deadlocks can be prevented (providng no deletes are done within the transaction).

Since snapshot isolation level is not implemented in all RDBMS systems and needs to be activated on a database, this cannot become the new default, therefore isolation level has been made configurable